### PR TITLE
Optimize tests and refactor Requester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.phar
 /vendor/
+.phpunit*
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,12 @@
 {
     "name": "vitorhugoro1/deta-base-php",
     "description": "Basic Deta Base Http API wrapper.",
-    "authors": [
-        {
-            "name": "Vitor Hugo Rodrigues",
-            "email": "vitorhugo.ro10@gmail.com"
-        }
-    ],
+    "authors": [{
+        "name": "Vitor Hugo Rodrigues",
+        "email": "vitorhugo.ro10@gmail.com"
+    }],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "guzzlehttp/guzzle": "^7.3",
         "ext-json": "*"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,30 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap = "vendor/autoload.php"
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    syntaxCheck                 = "false">
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
     <php>
         <env name="APP_ENV" value="testing"/>
     </php>
-
 </phpunit>

--- a/src/Deta.php
+++ b/src/Deta.php
@@ -8,38 +8,19 @@ use VitorHugoRo\Deta\Item;
 
 class Deta
 {
-    private string $baseUrl;
-
-    private string $apiVersion;
-
-    private string $projectKey;
-
-    private string $projectId;
-
-    private ?string $baseName = null;
-
-    private DetaRequest $client;
-
     public function __construct(
-        string $projectId,
-        string $projectKey,
-        ?string $baseName = null,
-        string $baseUrl = 'https://database.deta.sh',
-        string $apiVersion = 'v1'
+        private string $projectId,
+        private string $projectKey,
+        private ?string $baseName = null,
+        private ?DetaRequest $client = null
     ) {
-        $this->projectId = $projectId;
-        $this->projectKey = $projectKey;
-        $this->baseName = $baseName;
-        $this->baseUrl = $baseUrl;
-        $this->apiVersion = $apiVersion;
-
-        $this->client = new DetaRequest(
-            "{$this->baseUrl}/{$this->apiVersion}/{$this->projectId}/",
+        $this->client = $this->client ?? new DetaRequest(
+            $this->projectId,
             $this->projectKey
         );
     }
 
-    public function setBaseName(string $baseName): self
+    public function setBaseName(string $baseName): Deta
     {
         $this->baseName = $baseName;
 

--- a/src/Deta.php
+++ b/src/Deta.php
@@ -20,6 +20,13 @@ class Deta
         );
     }
 
+    /**
+     * Set a Deta Base
+     *
+     * @param string $baseName
+     *
+     * @return Deta
+     */
     public function setBaseName(string $baseName): Deta
     {
         $this->baseName = $baseName;
@@ -27,6 +34,11 @@ class Deta
         return $this;
     }
 
+    /**
+     * Query or Fetch all data from selected Deta Base
+     *
+     * @return \VitorHugoRo\Deta\Responses\QueryResponse
+     */
     public function fetch(): QueryResponse
     {
         if (!$this->baseName) {
@@ -42,6 +54,14 @@ class Deta
         );
     }
 
+    /**
+     * Insert a new item on selected Deta Base,
+     * if not provide an key then this will be automatic generated.
+     *
+     * @param array $params
+     *
+     * @return \VitorHugoRo\Deta\Item
+     */
     public function insert(array $params): Item
     {
         if (!$this->baseName) {
@@ -58,6 +78,9 @@ class Deta
     }
 
     /**
+     * Update a Item from a selected Deta Base
+     * Can update with many ways who you can check on Deta Documentation.
+     *
      * @param string $key
      * @param array $set
      * @param array $increment
@@ -85,6 +108,13 @@ class Deta
         return $this->get($key);
     }
 
+    /**
+     * Get a Item from selected Deta Base
+     *
+     * @param string $key
+     *
+     * @return \VitorHugoRo\Deta\Item
+     */
     public function get(string $key): Item
     {
         if (!$this->baseName) {
@@ -96,6 +126,13 @@ class Deta
         return Item::fromResponse($response);
     }
 
+    /**
+     * Delete a Item from a selected Deta Base then return if is sucessfull
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
     public function delete(string $key): bool
     {
         if (!$this->baseName) {

--- a/src/DetaRequest.php
+++ b/src/DetaRequest.php
@@ -3,19 +3,19 @@
 namespace VitorHugoRo\Deta;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use VitorHugoRo\Deta\Exceptions\RequestException;
 
 class DetaRequest
 {
-    private Client $client;
-
     public function __construct(
         private string $projectId,
         private string $projectKey,
-        private string $baseUri = 'https://database.deta.sh/v1'
+        private string $baseUri = 'https://database.deta.sh/v1',
+        private ?ClientInterface $client = null
     ) {
-        $this->client = new Client([
+        $this->client = $client ?? new Client([
             'base_uri' => "{$this->baseUri}/{$this->projectId}/",
             'headers' => [
                 'X-API-Key' => $this->projectKey,
@@ -23,6 +23,13 @@ class DetaRequest
             ],
             'http_errors' => false
         ]);
+    }
+
+    public function setClient(ClientInterface $client): DetaRequest
+    {
+        $this->client = $client;
+
+        return $this;
     }
 
     public function request(string $method, string $uri, array $options = []): array

--- a/src/DetaRequest.php
+++ b/src/DetaRequest.php
@@ -4,19 +4,21 @@ namespace VitorHugoRo\Deta;
 
 use GuzzleHttp\Client;
 use Psr\Http\Message\ResponseInterface;
+use VitorHugoRo\Deta\Exceptions\RequestException;
 
 class DetaRequest
 {
     private Client $client;
 
     public function __construct(
-        string $baseUri,
-        string $projectKey
+        private string $projectId,
+        private string $projectKey,
+        private string $baseUri = 'https://database.deta.sh/v1'
     ) {
         $this->client = new Client([
-            'base_uri' => $baseUri,
+            'base_uri' => "{$this->baseUri}/{$this->projectId}/",
             'headers' => [
-                'X-API-Key' => $projectKey,
+                'X-API-Key' => $this->projectKey,
                 'Content-Type' => 'application/json'
             ],
             'http_errors' => false
@@ -32,12 +34,15 @@ class DetaRequest
         return json_decode($response->getBody(), true);
     }
 
-    private function checkErrors(ResponseInterface $response)
+    private function checkErrors(ResponseInterface $response): void
     {
         if (in_array($response->getStatusCode(), [200, 201], true)) {
             return;
         }
 
-        // Add error traits
+        throw new RequestException(
+            (string) $response->getBody(),
+            $response->getStatusCode()
+        );
     }
 }

--- a/src/Exceptions/RequestException.php
+++ b/src/Exceptions/RequestException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace VitorHugoRo\Deta\Exceptions;
+
+use Exception;
+
+class RequestException extends Exception
+{
+}

--- a/src/Item.php
+++ b/src/Item.php
@@ -6,22 +6,18 @@ use VitorHugoRo\Deta\Exceptions\RequiredItemFieldException;
 
 class Item
 {
-    private $key;
-
-    private $body;
-
-    public function __construct(string $key, array $body)
-    {
-        $this->key = $key;
-        $this->body = $body;
+    public function __construct(
+        private string $key,
+        private array $body
+    ) {
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
 
-    public function getBody()
+    public function getBody(): array
     {
         return $this->body;
     }

--- a/src/Responses/QueryResponse.php
+++ b/src/Responses/QueryResponse.php
@@ -6,31 +6,19 @@ use VitorHugoRo\Deta\Item;
 
 class QueryResponse
 {
-    /**
-     * @var array<Item>
-     */
-    private array $items;
-
-    private int $size;
-
-    private ?string $lastKey;
-
     public function __construct(
-        array $items,
-        int $size,
-        ?string $lastKey = null
+        private array $items,
+        private int $size,
+        private ?string $lastKey = null
     ) {
-        $this->items = $items;
-        $this->size = $size;
-        $this->lastKey = $lastKey;
     }
 
-    public function getLastKey()
+    public function getLastKey(): ?string
     {
         return $this->lastKey;
     }
 
-    public function getSize()
+    public function getSize(): int
     {
         return $this->size;
     }


### PR DESCRIPTION
Make some breaking changes on `Deta`, who break the old implementation but make this new more readable and extensive for custom implementations.

- Adding docblocks to helper understanding what could you do with method.
- Change tests to use `Mockery` instead of Deta HTTP Api itself, make tests more stable.